### PR TITLE
Add 'to-lrform' command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,6 +311,33 @@ generate_to_imag_argparser(CLI::App        &app_,
 
 static
 void
+generate_to_lrform_argparser(CLI::App          &app_,
+                             Options::ToLRFORM &options_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("to-lrform","convert image to raw LRFORM");
+  subcmd->add_option("filepaths",options_.filepaths)
+    ->description("path to image")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+  subcmd->add_option("-o,--output-path",options_.output_path)
+    ->description("Path to output file")
+    ->type_name("PATH")
+    ->take_last();
+  subcmd->add_option("-i,--ignore-target-ext",options_.ignore_target_ext)
+    ->description("Ignore files with target extension")
+    ->default_val(false)
+    ->default_str("false")
+    ->take_last();
+
+  subcmd->callback(std::bind(SubCmd::to_lrform,
+                             std::cref(options_)));
+}
+
+static
+void
 generate_to_bmp_argparser(CLI::App         &app_,
                           Options::ToImage &options_)
 {
@@ -430,6 +457,7 @@ generate_argparser(CLI::App &app_,
   generate_to_cel_argparser(app_,options_.to_cel);
   generate_to_banner_argparser(app_,options_.to_banner);
   generate_to_imag_argparser(app_,options_.to_imag);
+  generate_to_lrform_argparser(app_,options_.to_lrform);  
   generate_to_bmp_argparser(app_,options_.to_image);
   generate_to_png_argparser(app_,options_.to_image);
   generate_to_jpg_argparser(app_,options_.to_image);

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -112,6 +112,13 @@ public:
     bool    ignore_target_ext;
   };
 
+  struct ToLRFORM
+  {
+    PathVec filepaths;
+    Path    output_path;
+    bool    ignore_target_ext;
+  };
+
   struct ToImage
   {
     PathVec filepaths;
@@ -132,6 +139,7 @@ public:
   ToCEL      to_cel;
   ToBanner   to_banner;
   ToIMAG     to_imag;
+  ToLRFORM   to_lrform;
   ToImage    to_image;
   ToNFSSHPM  to_nfs_shpm;
 };

--- a/src/subcmd.hpp
+++ b/src/subcmd.hpp
@@ -30,6 +30,7 @@ namespace SubCmd
   void to_cel(const Options::ToCEL &opts);
   void to_banner(const Options::ToBanner &opts);
   void to_imag(const Options::ToIMAG &opts);
+  void to_lrform(const Options::ToLRFORM &opts);
   void to_stb_image(const Options::ToImage &opts,
                     const std::string      &type);
   void to_nfs_shpm(const Options::ToNFSSHPM &opts);

--- a/src/subcmd_to_lrform.cpp
+++ b/src/subcmd_to_lrform.cpp
@@ -1,0 +1,179 @@
+/*
+  ISC License
+
+  Copyright (c) 2022, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "bitmap.hpp"
+#include "byteswap.hpp"
+#include "bytevec.hpp"
+#include "convert.hpp"
+#include "options.hpp"
+#include "read_file.hpp"
+#include "stbi.hpp"
+#include "filerw.hpp"
+
+#include "fmt.hpp"
+
+#include <filesystem>
+#include <cstring>
+
+namespace fs = std::filesystem;
+
+
+namespace l
+{
+  static
+  fs::path
+  generate_filepath(const fs::path    orig_filepath_,
+                    const std::string ext_,
+                    const fs::path    output_filepath_)
+  {
+    fs::path filepath;
+
+    if(output_filepath_.empty())
+      filepath = "{filepath}.{ext}";
+    else
+      filepath = output_filepath_;
+
+    try
+      {
+        filepath = fmt::format(filepath.string(),
+                               fmt::arg("filepath",orig_filepath_),
+                               fmt::arg("stem",orig_filepath_.stem()),
+                               fmt::arg("filename",orig_filepath_.filename()),
+                               fmt::arg("parentpath",orig_filepath_.parent_path()),
+                               fmt::arg("ext",ext_));
+      }
+    catch(const std::runtime_error &e_)
+      {
+        std::string what{e_.what()};
+
+        if(what == "argument not found")
+          throw std::runtime_error("unknown output file template argument");
+        throw e_;
+      }
+
+    return filepath;
+  }
+
+  static
+  void
+  to_lrform(const fs::path &filepath_,
+            const fs::path &output_filepath_)
+  {
+    BitmapVec bitmaps;
+
+    convert::to_bitmap(filepath_,bitmaps);
+    if(bitmaps.empty())
+      throw fmt::exception("failed to convert");
+
+    for(auto const &bitmap : bitmaps)
+      {
+        int rv;
+        FileRW f;
+        ByteVec pdat;
+        fs::path output_filepath;
+
+        output_filepath = l::generate_filepath(filepath_,"lrform",output_filepath_);
+
+        rv = f.open_write_trunc(output_filepath);
+        if(rv < 0)
+          {
+            fmt::print(" - {}: {}\n",output_filepath,strerror(-rv));
+            continue;
+          }
+
+        convert::bitmap_to_uncoded_unpacked_lrform_16bpp(bitmap,pdat);
+
+        f.w(pdat);
+
+        f.close();
+
+        fmt::print(" - {}\n",output_filepath);
+      }
+  }
+
+  static
+  bool
+  same_extension(const fs::path          &filepath_,
+                 const Options::ToLRFORM &opts_)
+  {
+    if(opts_.ignore_target_ext == false)
+      return false;
+    if(filepath_.has_extension() == false)
+      return false;
+
+    return (filepath_.extension() == ".lrform");
+  }
+
+  static
+  void
+  handle_file(const fs::path          &filepath_,
+              const Options::ToLRFORM &opts_)
+  {
+    fmt::print("{}:\n",filepath_);
+
+    if(l::same_extension(filepath_,opts_))
+      {
+        fmt::print(" - WARNING - skipping file with target extension\n");
+        return;
+      }
+
+    try
+      {
+        l::to_lrform(filepath_,opts_.output_path);
+      }
+    catch(const std::system_error &e_)
+      {
+        fmt::print(" - ERROR - {} ({})\n",e_.what(),e_.code().message());
+      }
+    catch(const std::runtime_error &e_)
+      {
+        fmt::print(" - ERROR - {}\n",e_.what());
+      }
+  }
+
+  static
+  void
+  handle_dir(const fs::path          &dirpath_,
+             const Options::ToLRFORM &opts_)
+  {
+    for(const fs::directory_entry &de : fs::recursive_directory_iterator(dirpath_))
+      {
+        if(!de.is_regular_file())
+          continue;
+
+        l::handle_file(de.path(),opts_);
+      }
+  }
+}
+
+namespace SubCmd
+{
+  void
+  to_lrform(const Options::ToLRFORM &opts_)
+  {
+    for(auto const &filepath : opts_.filepaths)
+      {
+        fs::directory_entry de(filepath);
+
+        if(de.is_regular_file())
+          l::handle_file(de.path(),opts_);
+        else if(de.is_directory())
+          l::handle_dir(de.path(),opts_);
+      }
+  }
+}


### PR DESCRIPTION
Generates a file in raw LRFORM format.

IMAG files are just raw LRFORM with a header. Having that header leads to inefficient file loading.