### PR TITLE
Guard packed CEL literals against ALPHA sentinels

### DIFF
--- a/src/cel_packer.cpp
+++ b/src/cel_packer.cpp
@@ -26,12 +26,12 @@
 
   0. Initialize the abstract packed image metadata.
   1. Convert each bitmap row to packed-source pixels and run dynamic
-     programming over that row to find the minimum-cost legal encoding.
+  programming over that row to find the minimum-cost legal encoding.
   2. Encode the abstract packets as 3DO packed row bitstreams.
   3. Pad each row bitstream to at least 2 words and then to a 32-bit
-     boundary.
+  boundary.
   4. Serialize the row bitstreams into a byte vector for writing to
-     disk.
+  disk.
 */
 
 #include "cel_packer.hpp"
@@ -61,7 +61,7 @@ static constexpr u32 MAX_PACKET_PIXELS = (1u << DATA_PACKET_PIXEL_COUNT_SIZE);
 
 struct PackedDataPacket
 {
-  uint8_t type = PACK_EOL;
+  uint8_t type;
   uint8_t bpp = 0;
   u32 count = 0;
   u32 pixel = 0;
@@ -95,7 +95,6 @@ struct RowChoice
   size_t begin;
   size_t end;
   u32 type;
-  u32 cost;
 };
 
 
@@ -115,7 +114,9 @@ PackedDataPacketVec::pixel_count() const
 
   c = 0;
   for(const auto &pdp : *this)
-    c += pdp.pixel_count();
+    {
+      c += pdp.pixel_count();
+    }
 
   return c;
 }
@@ -127,7 +128,9 @@ PackedDataPacketVec::size_in_bits() const
 
   c = 0;
   for(const auto &pdp : *this)
-    c += pdp.size_in_bits();
+    {
+      c += pdp.size_in_bits();
+    }
 
   return c;
 }
@@ -164,7 +167,9 @@ AbstractPackedImage::size_in_bits() const
 
   c = 0;
   for(const auto &pdpvec : *this)
-    c += pdpvec.size_in_bits();
+    {
+      c += pdpvec.size_in_bits();
+    }
 
   return c;
 }
@@ -231,35 +236,45 @@ PackedDataPacket
 build_packet_from_range(const std::vector<u32> &pixels_,
                         const u32               bpp_,
                         const size_t            begin_,
-                        const size_t            end_)
+                        const size_t            end_,
+                        const u32               type_,
+                        const bool              zero_transparency_)
 {
   PackedDataPacket pdp;
   const size_t len = (end_ - begin_);
 
   pdp.bpp = bpp_;
   pdp.count = len;
+  pdp.type = type_;
   if(len == 0)
     return pdp;
 
-  if(pixels_[begin_] == ALPHA)
-    {
-      pdp.type = PACK_TRANSPARENT;
-      return pdp;
-    }
+  if(type_ == PACK_TRANSPARENT)
+    return pdp;
 
-  if((len >= 2) &&
-     std::all_of(pixels_.begin() + begin_ + 1,
-                 pixels_.begin() + end_,
-                 [&](const u32 pixel_) { return pixel_ == pixels_[begin_]; }))
+  if(type_ == PACK_PACKED)
     {
-      pdp.type = PACK_PACKED;
+      if(pixels_[begin_] == ALPHA)
+        throw std::runtime_error("cel_packer: transparent packed pixel");
+
       pdp.pixel = pixels_[begin_];
       return pdp;
     }
 
-  pdp.type = PACK_LITERAL;
-  pdp.pixels.assign(pixels_.begin() + begin_,
-                    pixels_.begin() + end_);
+  if(type_ != PACK_LITERAL)
+    throw std::runtime_error("cel_packer: invalid packet type");
+
+  pdp.pixels.reserve(len);
+  for(size_t i = begin_; i < end_; ++i)
+    {
+      if(pixels_[i] != ALPHA)
+        pdp.pixels.emplace_back(pixels_[i]);
+      else if(zero_transparency_)
+        pdp.pixels.emplace_back(0);
+      else
+        throw std::runtime_error("cel_packer: ALPHA sentinel found in literal range");
+    }
+
   return pdp;
 }
 
@@ -304,13 +319,14 @@ pass1_choice_is_better(const RowChoice &candidate_,
     return candidate_bits < current_bits;
   if(candidate_count != current_count)
     return candidate_count > current_count;
-  return candidate_.type < current_.type;
+  return candidate_.type > current_.type;
 }
 
 static
 PackedDataPacketVec
 pass1_optimize_row_encoding(const std::vector<u32> &pixels_,
-                            const u32               bpp_)
+                            const u32               bpp_,
+                            const bool              zero_transparency_)
 {
   const size_t n = pixels_.size();
   std::vector<u32> best_cost(n + 1,std::numeric_limits<u32>::max());
@@ -328,26 +344,36 @@ pass1_optimize_row_encoding(const std::vector<u32> &pixels_,
     {
       auto consider_choice = [&](const size_t end_,
                                  const u32    type_)
-        {
-          const u32 packet_cost = packet_size_in_bits(type_,
-                                                      end_ - pos,
-                                                      bpp_);
-          const u32 total_cost = packet_cost + best_cost[end_];
-          const RowChoice choice = {pos,end_,type_,total_cost};
+      {
+        const u32 packet_cost = packet_size_in_bits(type_,
+                                                    end_ - pos,
+                                                    bpp_);
+        const u32 total_cost = packet_cost + best_cost[end_];
+        const RowChoice choice = {pos,end_,type_};
 
-          if(!has_choice[pos] ||
-             (total_cost < best_cost[pos]) ||
-             ((total_cost == best_cost[pos]) &&
-              pass1_choice_is_better(choice,best_choice[pos],bpp_)))
-            {
-              best_cost[pos] = total_cost;
-              best_choice[pos] = choice;
-              has_choice[pos] = true;
-            }
-        };
+        if(!has_choice[pos] ||
+           (total_cost < best_cost[pos]) ||
+           ((total_cost == best_cost[pos]) &&
+            pass1_choice_is_better(choice,best_choice[pos],bpp_)))
+          {
+            best_cost[pos] = total_cost;
+            best_choice[pos] = choice;
+            has_choice[pos] = true;
+          }
+      };
 
       if(transparent_suffix[pos])
         consider_choice(n,PACK_EOL);
+
+      if(zero_transparency_)
+        {
+          for(size_t end = pos + 1;
+              (end <= n) && ((end - pos) <= MAX_PACKET_PIXELS);
+              ++end)
+            {
+              consider_choice(end,PACK_LITERAL);
+            }
+        }
 
       if(pixels_[pos] == ALPHA)
         {
@@ -374,14 +400,19 @@ pass1_optimize_row_encoding(const std::vector<u32> &pixels_,
                 (pixels_[packed_end] != ALPHA))
             ++packed_end;
 
-          for(size_t end = pos + 1;
-              (end <= n) && ((end - pos) <= MAX_PACKET_PIXELS);
-              ++end)
+          if(!zero_transparency_)
             {
-              consider_choice(end,PACK_LITERAL);
+              for(size_t end = pos + 1;
+                  (end <= n) && ((end - pos) <= MAX_PACKET_PIXELS) && (pixels_[end - 1] != ALPHA);
+                  ++end)
+                {
+                  consider_choice(end,PACK_LITERAL);
+                }
+            }
 
-              if((end - pos >= 2) && (end <= packed_end))
-                consider_choice(end,PACK_PACKED);
+          for(size_t end = pos + 2; end <= packed_end; ++end)
+            {
+              consider_choice(end,PACK_PACKED);
             }
         }
     }
@@ -406,8 +437,9 @@ pass1_optimize_row_encoding(const std::vector<u32> &pixels_,
       packet = build_packet_from_range(pixels_,
                                        bpp_,
                                        choice.begin,
-                                       choice.end);
-      packet.type = choice.type;
+                                       choice.end,
+                                       choice.type,
+                                       zero_transparency_);
       out.emplace_back(std::move(packet));
       pos = choice.end;
     }
@@ -419,13 +451,15 @@ static
 void
 pass1_optimize_rows(const Bitmap            &b_,
                     const RGBA8888Converter &pc_,
-                    AbstractPackedImage     &api_)
+                    AbstractPackedImage     &api_,
+                    const bool               zero_transparency_)
 {
   for(size_t row = 0; row < api_.size(); row++)
     {
       const auto pixels = build_row_pixels(b_,pc_,row);
       api_[row] = pass1_optimize_row_encoding(pixels,
-                                              api_.bpp);
+                                              api_.bpp,
+                                              zero_transparency_);
     }
 }
 
@@ -471,6 +505,10 @@ pass2_api_to_bitstreams(const AbstractPackedImage &api_,
             }
         }
 
+      if((pdpvec.pixel_count() < api_.line_width) &&
+         (pdpvec.empty() || pdpvec.back().type != PACK_EOL))
+        row.write(DATA_PACKET_DATA_TYPE_SIZE,PACK_EOL);
+
       // Finalize the row offset header before padding.
       {
         u64 word_offset;
@@ -515,17 +553,67 @@ pass4_bitstreams_to_bytevec(const BitStreamVec &rows_,
     }
 }
 
+static
 void
-CelPacker::pack(const Bitmap            &b_,
-                const RGBA8888Converter &pc_,
-                ByteVec                 &pdat_)
+pack_with_mode(const Bitmap            &b_,
+               const RGBA8888Converter &pc_,
+               const bool               zero_transparency_,
+               ByteVec                 &pdat_)
 {
   AbstractPackedImage api;
   BitStreamVec rows;
 
   pass0_init_api(b_,pc_,api);
-  pass1_optimize_rows(b_,pc_,api);
+  pass1_optimize_rows(b_,pc_,api,zero_transparency_);
   pass2_api_to_bitstreams(api,rows);
   pass3_pad_rows(rows);
   pass4_bitstreams_to_bytevec(rows,pdat_);
+}
+
+static
+bool
+can_use_zero_transparency(const Bitmap            &b_,
+                          const RGBA8888Converter &pc_)
+{
+  bool has_transparency = false;
+
+  for(size_t y = 0; y < b_.h; ++y)
+    {
+      for(size_t x = 0; x < b_.w; ++x)
+        {
+          const RGBA8888 *pixel = b_.xy(x,y);
+
+          if(pixel->a == 0)
+            has_transparency = true;
+          else if(pc_.convert(pixel) == 0)
+            return false;
+        }
+    }
+
+  return has_transparency;
+}
+
+bool
+CelPacker::pack(const Bitmap            &b_,
+                const RGBA8888Converter &pc_,
+                ByteVec                 &pdat_,
+                const bool               allow_zero_transparency_)
+{
+  ByteVec regular_pdat;
+
+  ::pack_with_mode(b_,pc_,false,regular_pdat);
+  if(allow_zero_transparency_ && ::can_use_zero_transparency(b_,pc_))
+    {
+      ByteVec zero_pdat;
+
+      ::pack_with_mode(b_,pc_,true,zero_pdat);
+      if(zero_pdat.size() < regular_pdat.size())
+        {
+          pdat_ = std::move(zero_pdat);
+          return true;
+        }
+    }
+
+  pdat_ = std::move(regular_pdat);
+  return false;
 };

--- a/src/cel_packer.hpp
+++ b/src/cel_packer.hpp
@@ -27,8 +27,9 @@
 
 namespace CelPacker
 {
-  void
+  bool
   pack(const Bitmap            &b_,
        const RGBA8888Converter &pc_,
-       ByteVec                 &pdat_);
+       ByteVec                 &pdat_,
+       bool                     allow_zero_transparency_ = true);
 }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -617,22 +617,24 @@ convert::bitmap_to_uncoded_unpacked_lrform_16bpp(const Bitmap &bitmap_,
     }
 }
 
-void
+bool
 convert::bitmap_to_uncoded_packed_linear_8bpp(const Bitmap &bitmap_,
-                                              ByteVec      &pdat_)
+                                              ByteVec      &pdat_,
+                                              const bool    allow_zero_transparency_)
 {
   RGBA8888Converter pc(BPP_8);
 
-  CelPacker::pack(bitmap_,pc,pdat_);
+  return CelPacker::pack(bitmap_,pc,pdat_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_uncoded_packed_linear_16bpp(const Bitmap &bitmap_,
-                                               ByteVec      &pdat_)
+                                               ByteVec      &pdat_,
+                                               const bool    allow_zero_transparency_)
 {
   RGBA8888Converter pc(BPP_16);
 
-  CelPacker::pack(bitmap_,pc,pdat_);
+  return CelPacker::pack(bitmap_,pc,pdat_,allow_zero_transparency_);
 }
 
 static
@@ -749,14 +751,39 @@ convert::bitmap_to_coded_unpacked_linear_16bpp(const Bitmap &bitmap_,
 }
 
 static
-void
+bool
+reserve_zero_plut_entry(const int bpp_,
+                        PLUT     &plut_)
+{
+  for(size_t i = 0; i < plut_.size(); ++i)
+    {
+      if(plut_[i] == 0)
+        {
+          if(i != 0)
+            {
+              plut_.erase(plut_.begin() + i);
+              plut_.insert(plut_.begin(),0);
+            }
+
+          return true;
+        }
+    }
+
+  if(plut_.size() >= plut_.min_size(bpp_))
+    return false;
+
+  plut_.insert(plut_.begin(),0);
+  return true;
+}
+
+static
+bool
 bitmap_to_coded_packed_linear_Xbpp(const Bitmap &bitmap_,
                                    const int     bpp_,
                                    ByteVec      &pdat_,
-                                   PLUT         &plut_)
+                                   PLUT         &plut_,
+                                   const bool    allow_zero_transparency_)
 {
-  RGBA8888Converter pc(bpp_,plut_);
-
   ::check_coded_colors(bitmap_,bpp_);
 
   if(bitmap_.has("external-palette"))
@@ -784,55 +811,78 @@ bitmap_to_coded_packed_linear_Xbpp(const Bitmap &bitmap_,
       plut_.build(bitmap_);
     }
 
-  CelPacker::pack(bitmap_,pc,pdat_);
+  if(allow_zero_transparency_ && !bitmap_.has("external-palette"))
+    {
+      const PLUT regular_plut = plut_;
+
+      if(::reserve_zero_plut_entry(bpp_,plut_))
+        {
+          RGBA8888Converter pc(bpp_,plut_);
+
+          if(CelPacker::pack(bitmap_,pc,pdat_,true))
+            return true;
+        }
+
+      plut_ = regular_plut;
+    }
+
+  RGBA8888Converter pc(bpp_,plut_);
+  CelPacker::pack(bitmap_,pc,pdat_,false);
+  return false;
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_1bpp(const Bitmap &bitmap_,
                                             ByteVec      &pdat_,
-                                            PLUT         &plut_)
+                                            PLUT         &plut_,
+                                            const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_1,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_1,pdat_,plut_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_2bpp(const Bitmap &bitmap_,
                                             ByteVec      &pdat_,
-                                            PLUT         &plut_)
+                                            PLUT         &plut_,
+                                            const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_2,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_2,pdat_,plut_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_4bpp(const Bitmap &bitmap_,
                                             ByteVec      &pdat_,
-                                            PLUT         &plut_)
+                                            PLUT         &plut_,
+                                            const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_4,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_4,pdat_,plut_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_6bpp(const Bitmap &bitmap_,
                                             ByteVec      &pdat_,
-                                            PLUT         &plut_)
+                                            PLUT         &plut_,
+                                            const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_6,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_6,pdat_,plut_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_8bpp(const Bitmap &bitmap_,
                                             ByteVec      &pdat_,
-                                            PLUT         &plut_)
+                                            PLUT         &plut_,
+                                            const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_8,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_8,pdat_,plut_,allow_zero_transparency_);
 }
 
-void
+bool
 convert::bitmap_to_coded_packed_linear_16bpp(const Bitmap &bitmap_,
                                              ByteVec      &pdat_,
-                                             PLUT         &plut_)
+                                             PLUT         &plut_,
+                                             const bool    allow_zero_transparency_)
 {
-  ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_16,pdat_,plut_);
+  return ::bitmap_to_coded_packed_linear_Xbpp(bitmap_,BPP_16,pdat_,plut_,allow_zero_transparency_);
 }
 
 void
@@ -985,7 +1035,7 @@ unpack_row(BitStreamReader &bs_,
         case PACK_EOL:
           break;
         }
-    } while((type != PACK_EOL) && (pw_.row_pixels_remaining() != 0));
+    } while((type != PACK_EOL) && !pw_.row_filled());
 }
 
 static
@@ -1260,52 +1310,62 @@ convert::coded_unpacked_linear_16bpp_to_bitmap(cPDAT          pdat_,
   ::coded_unpacked_linear_to_bitmap(16,pdat_,plut_,pluta_,bitmap_);
 }
 
-void
+bool
 convert::bitmap_to_cel(const Bitmap  &bitmap_,
                        const CelType &celtype_,
                        ByteVec       &pdat_,
-                       PLUT          &plut_)
+                       PLUT          &plut_,
+                       const bool     allow_zero_transparency_)
 {
   switch(celtype_.switchable)
     {
     case (UNCODED|UNPACKED|LRFORM|BPP_16):
-      return convert::bitmap_to_uncoded_unpacked_lrform_16bpp(bitmap_,pdat_);
+      convert::bitmap_to_uncoded_unpacked_lrform_16bpp(bitmap_,pdat_);
+      return false;
 
     case (UNCODED|UNPACKED|LINEAR|BPP_8):
-      return convert::bitmap_to_uncoded_unpacked_linear_8bpp(bitmap_,pdat_);
+      convert::bitmap_to_uncoded_unpacked_linear_8bpp(bitmap_,pdat_);
+      return false;
     case (UNCODED|UNPACKED|LINEAR|BPP_16):
-      return convert::bitmap_to_uncoded_unpacked_linear_16bpp(bitmap_,pdat_);
+      convert::bitmap_to_uncoded_unpacked_linear_16bpp(bitmap_,pdat_);
+      return false;
 
     case (UNCODED|PACKED|LINEAR|BPP_8):
-      return convert::bitmap_to_uncoded_packed_linear_8bpp(bitmap_,pdat_);
+      return convert::bitmap_to_uncoded_packed_linear_8bpp(bitmap_,pdat_,allow_zero_transparency_);
     case (UNCODED|PACKED|LINEAR|BPP_16):
-      return convert::bitmap_to_uncoded_packed_linear_16bpp(bitmap_,pdat_);
+      return convert::bitmap_to_uncoded_packed_linear_16bpp(bitmap_,pdat_,allow_zero_transparency_);
 
     case (CODED|UNPACKED|LINEAR|BPP_1):
-      return convert::bitmap_to_coded_unpacked_linear_1bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_1bpp(bitmap_,pdat_,plut_);
+      return false;
     case (CODED|UNPACKED|LINEAR|BPP_2):
-      return convert::bitmap_to_coded_unpacked_linear_2bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_2bpp(bitmap_,pdat_,plut_);
+      return false;
     case (CODED|UNPACKED|LINEAR|BPP_4):
-      return convert::bitmap_to_coded_unpacked_linear_4bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_4bpp(bitmap_,pdat_,plut_);
+      return false;
     case (CODED|UNPACKED|LINEAR|BPP_6):
-      return convert::bitmap_to_coded_unpacked_linear_6bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_6bpp(bitmap_,pdat_,plut_);
+      return false;
     case (CODED|UNPACKED|LINEAR|BPP_8):
-      return convert::bitmap_to_coded_unpacked_linear_8bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_8bpp(bitmap_,pdat_,plut_);
+      return false;
     case (CODED|UNPACKED|LINEAR|BPP_16):
-      return convert::bitmap_to_coded_unpacked_linear_16bpp(bitmap_,pdat_,plut_);
+      convert::bitmap_to_coded_unpacked_linear_16bpp(bitmap_,pdat_,plut_);
+      return false;
 
     case (CODED|PACKED|LINEAR|BPP_1):
-      return convert::bitmap_to_coded_packed_linear_1bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_1bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
     case (CODED|PACKED|LINEAR|BPP_2):
-      return convert::bitmap_to_coded_packed_linear_2bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_2bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
     case (CODED|PACKED|LINEAR|BPP_4):
-      return convert::bitmap_to_coded_packed_linear_4bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_4bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
     case (CODED|PACKED|LINEAR|BPP_6):
-      return convert::bitmap_to_coded_packed_linear_6bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_6bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
     case (CODED|PACKED|LINEAR|BPP_8):
-      return convert::bitmap_to_coded_packed_linear_8bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_8bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
     case (CODED|PACKED|LINEAR|BPP_16):
-      return convert::bitmap_to_coded_packed_linear_16bpp(bitmap_,pdat_,plut_);
+      return convert::bitmap_to_coded_packed_linear_16bpp(bitmap_,pdat_,plut_,allow_zero_transparency_);
 
     default:
       throw fmt::exception("invalid combination of attributes: "

--- a/src/convert.hpp
+++ b/src/convert.hpp
@@ -63,10 +63,11 @@ namespace convert
   void to_bitmap(const std::filesystem::path &filepath,
                  BitmapVec                   &bitmaps);
 
-  void bitmap_to_cel(const Bitmap  &bitmap,
+  bool bitmap_to_cel(const Bitmap  &bitmap,
                      const CelType &celtype,
                      ByteVec       &pdat,
-                     PLUT          &plut);
+                     PLUT          &plut,
+                     bool           allow_zero_transparency = true);
 
   void bitmap_to_uncoded_unpacked_lrform_16bpp(const Bitmap &bitmap,
                                                ByteVec      &pdat);
@@ -76,10 +77,12 @@ namespace convert
   void bitmap_to_uncoded_unpacked_linear_16bpp(const Bitmap &bitmap,
                                                ByteVec      &pdat);
 
-  void bitmap_to_uncoded_packed_linear_8bpp(const Bitmap &bitmap,
-                                            ByteVec      &pdat);
-  void bitmap_to_uncoded_packed_linear_16bpp(const Bitmap &bitmap,
-                                             ByteVec      &pdat);
+  bool bitmap_to_uncoded_packed_linear_8bpp(const Bitmap &bitmap,
+                                            ByteVec      &pdat,
+                                            bool          allow_zero_transparency = true);
+  bool bitmap_to_uncoded_packed_linear_16bpp(const Bitmap &bitmap,
+                                             ByteVec      &pdat,
+                                             bool          allow_zero_transparency = true);
 
   void bitmap_to_coded_unpacked_linear_1bpp(const Bitmap &bitmap,
                                             ByteVec      &pdat,
@@ -100,24 +103,30 @@ namespace convert
                                              ByteVec      &pdat,
                                              PLUT         &plut);
 
-  void bitmap_to_coded_packed_linear_1bpp(const Bitmap &bitmap,
+  bool bitmap_to_coded_packed_linear_1bpp(const Bitmap &bitmap,
                                           ByteVec      &pdat,
-                                          PLUT         &plut);
-  void bitmap_to_coded_packed_linear_2bpp(const Bitmap &bitmap,
+                                          PLUT         &plut,
+                                          bool          allow_zero_transparency = true);
+  bool bitmap_to_coded_packed_linear_2bpp(const Bitmap &bitmap,
                                           ByteVec      &pdat,
-                                          PLUT         &plut);
-  void bitmap_to_coded_packed_linear_4bpp(const Bitmap &bitmap,
+                                          PLUT         &plut,
+                                          bool          allow_zero_transparency = true);
+  bool bitmap_to_coded_packed_linear_4bpp(const Bitmap &bitmap,
                                           ByteVec      &pdat,
-                                          PLUT         &plut);
-  void bitmap_to_coded_packed_linear_6bpp(const Bitmap &bitmap,
+                                          PLUT         &plut,
+                                          bool          allow_zero_transparency = true);
+  bool bitmap_to_coded_packed_linear_6bpp(const Bitmap &bitmap,
                                           ByteVec      &pdat,
-                                          PLUT         &plut);
-  void bitmap_to_coded_packed_linear_8bpp(const Bitmap &bitmap,
+                                          PLUT         &plut,
+                                          bool          allow_zero_transparency = true);
+  bool bitmap_to_coded_packed_linear_8bpp(const Bitmap &bitmap,
                                           ByteVec      &pdat,
-                                          PLUT         &plut);
-  void bitmap_to_coded_packed_linear_16bpp(const Bitmap &bitmap,
+                                          PLUT         &plut,
+                                          bool          allow_zero_transparency = true);
+  bool bitmap_to_coded_packed_linear_16bpp(const Bitmap &bitmap,
                                            ByteVec      &pdat,
-                                           PLUT         &plut);
+                                           PLUT         &plut,
+                                           bool          allow_zero_transparency = true);
 
   void uncoded_unpacked_linear_8bpp_to_bitmap(cPDAT   pdat,
                                               Bitmap &bitmap);

--- a/src/subcmd_to_cel.cpp
+++ b/src/subcmd_to_cel.cpp
@@ -234,11 +234,12 @@ namespace l
   }
 
   static
-  void
+  bool
   find_smallest_regular(Bitmap  &bitmap_,
                         CelType &celtype_,
                         PLUT    &plut_,
-                        ByteVec &pdat_)
+                        ByteVec &pdat_,
+                        const bool allow_zero_transparency_)
   {
     CelType tmp_celtype;
     PLUT    tmp_plut;
@@ -248,6 +249,8 @@ namespace l
     ByteVec best_pdat;
     CelType best_celtype;
     Bitmap  best_bitmap;
+    bool    tmp_zero_transparency;
+    bool    best_zero_transparency = false;
     std::array<bool,2>    packeds   = {false, true};
     std::array<bool,2>    codeds    = {false, true};
     std::array<uint8_t,6> bpps      = {1,2,4,6,8,16};
@@ -269,7 +272,11 @@ namespace l
                 tmp_celtype.coded  = coded;
                 try
                   {
-                    convert::bitmap_to_cel(bitmap_,tmp_celtype,tmp_pdat,tmp_plut);
+                    tmp_zero_transparency = convert::bitmap_to_cel(bitmap_,
+                                                                   tmp_celtype,
+                                                                   tmp_pdat,
+                                                                   tmp_plut,
+                                                                   allow_zero_transparency_);
                   }
                 catch(...)
                   {
@@ -283,6 +290,7 @@ namespace l
                 best_pdat    = tmp_pdat;
                 best_plut    = tmp_plut;
                 best_bitmap  = bitmap_;
+                best_zero_transparency = tmp_zero_transparency;
               }
           }
       }
@@ -291,14 +299,16 @@ namespace l
     plut_    = best_plut;
     pdat_    = best_pdat;
     bitmap_  = best_bitmap;
+    return best_zero_transparency;
   }
 
   static
-  void
+  bool
   find_smallest_rotation(Bitmap  &bitmap_,
                          CelType &celtype_,
                          PLUT    &plut_,
-                         ByteVec &pdat_)
+                         ByteVec &pdat_,
+                         const bool allow_zero_transparency_)
   {
     CelType tmp_celtype;
     PLUT    tmp_plut;
@@ -308,6 +318,8 @@ namespace l
     ByteVec best_pdat;
     CelType best_celtype;
     Bitmap  best_bitmap;
+    bool    tmp_zero_transparency;
+    bool    best_zero_transparency = false;
     std::array<int,4>     rotations = {0,90,180,270};
     std::array<bool,2>    packeds   = {false, true};
     std::array<bool,2>    codeds    = {false, true};
@@ -333,7 +345,11 @@ namespace l
                     tmp_celtype.coded  = coded;
                     try
                       {
-                        convert::bitmap_to_cel(bitmap_,tmp_celtype,tmp_pdat,tmp_plut);
+                        tmp_zero_transparency = convert::bitmap_to_cel(bitmap_,
+                                                                       tmp_celtype,
+                                                                       tmp_pdat,
+                                                                       tmp_plut,
+                                                                       allow_zero_transparency_);
                       }
                     catch(...)
                       {
@@ -347,6 +363,7 @@ namespace l
                     best_pdat    = tmp_pdat;
                     best_plut    = tmp_plut;
                     best_bitmap  = bitmap_;
+                    best_zero_transparency = tmp_zero_transparency;
                   }
               }
           }
@@ -356,6 +373,7 @@ namespace l
     plut_    = best_plut;
     pdat_    = best_pdat;
     bitmap_  = best_bitmap;
+    return best_zero_transparency;
   }
 
   static
@@ -369,6 +387,10 @@ namespace l
     CelType celtype;
     CelControlChunk ccc;
     fs::path filepath;
+    bool zero_transparency;
+    const bool allow_zero_transparency =
+      ((opts_.ccb_flags.bgnd != Options::Flag::SET) &&
+       (opts_.pre0_flags.bgnd != Options::Flag::SET));
 
     celtype.bpp    = opts_.bpp;
     celtype.coded  = opts_.coded;
@@ -376,11 +398,23 @@ namespace l
     celtype.packed = opts_.packed;
 
     if(opts_.find_smallest.empty())
-      convert::bitmap_to_cel(bitmap_,celtype,pdat,plut);
+      zero_transparency = convert::bitmap_to_cel(bitmap_,
+                                                 celtype,
+                                                 pdat,
+                                                 plut,
+                                                 allow_zero_transparency);
     else if(opts_.find_smallest == "regular")
-      l::find_smallest_regular(bitmap_,celtype,plut,pdat);
+      zero_transparency = l::find_smallest_regular(bitmap_,
+                                                   celtype,
+                                                   plut,
+                                                   pdat,
+                                                   allow_zero_transparency);
     else if(opts_.find_smallest == "rotation")
-      l::find_smallest_rotation(bitmap_,celtype,plut,pdat);
+      zero_transparency = l::find_smallest_rotation(bitmap_,
+                                                    celtype,
+                                                    plut,
+                                                    pdat,
+                                                    allow_zero_transparency);
     else
       throw std::runtime_error("Unknown request");
 
@@ -391,6 +425,11 @@ namespace l
 
     l::modify_ccb_flags(opts_.ccb_flags,ccc);
     l::modify_pre0_flags(opts_.pre0_flags,ccc);
+    if(zero_transparency)
+      {
+        ccc.ccb_Flags &= ~CCB_BGND;
+        ccc.ccb_PRE0  &= ~PRE0_BGND;
+      }
 
     filepath = l::generate_filepath(filepath_,
                                     opts_.output_path,


### PR DESCRIPTION
- Stop regular-mode literal candidate enumeration at ALPHA sentinels
- Reject ALPHA values in literal and packed packet ranges defensively
- Add zero-transparency packing and select it only when it produces smaller output
- Propagate the selected mode through coded and uncoded conversions
- Reserve palette index 0 and clear BGND/PRE0 flags when required
- Emit row EOL packets when encoded data does not fill the line